### PR TITLE
issue: Upgrade the starter to version 3.8.0.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>ca.uhn.hapi.fhir</groupId>
 	<artifactId>hapi-fhir-jpaserver-oauth</artifactId>
-	<version>3.3.0-SNAPSHOT</version>
+	<version>3.8.0-SNAPSHOT</version>
 	<packaging>war</packaging>
 	<name>HAPI FHIR MySQL OAuth JPA Server - Example</name>
 
@@ -18,15 +18,16 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
 		<!-- Dependency Versions -->
-		<derby_version>10.14.1.0</derby_version>
-		<jaxb_api_version>2.3.0</jaxb_api_version>
-		<jetty_version>9.4.8.v20171121</jetty_version>
+		<derby_version>10.14.2.0</derby_version>
+		<jaxb_api_version>2.3.1</jaxb_api_version>
+		<jetty_version>9.4.14.v20181114</jetty_version>
 		<phloc_schematron_version>2.7.1</phloc_schematron_version>
-		<spring_version>5.0.3.RELEASE</spring_version>
-		<thymeleaf-version>3.0.9.RELEASE</thymeleaf-version>
+		<spring_version>5.1.8.RELEASE</spring_version>
+		<thymeleaf-version>3.0.11.RELEASE</thymeleaf-version>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<ebay_cors_filter_version>1.0.1</ebay_cors_filter_version>
-		<hapi.version>3.3.0-SNAPSHOT</hapi.version>
+		<commons_dbcp2>2.6.0</commons_dbcp2>
+		<hapi.version>3.8.0</hapi.version>
 
 		<!-- Unit and integration tests management -->
 		<skip.unit.tests>false</skip.unit.tests>
@@ -92,7 +93,8 @@
 		<dependency>
 			<groupId>ca.uhn.hapi.fhir</groupId>
 			<artifactId>hapi-fhir-base</artifactId>
-			<version>${hapi.version}</version>
+<!--			<version>${hapi.version}</version> -->
+			<version>3.8.0-SNAPSHOT</version>
 		</dependency>
 
 		<!-- At least one "structures" JAR must also be included -->
@@ -183,7 +185,7 @@
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-dbcp2</artifactId>
-			<version>2.1.1</version>
+			<version>${commons_dbcp2}</version>
 		</dependency>
 
 		<!-- This example does not use Derby embedded database. We skip the dependencies. -->

--- a/src/main/java/ca/uhn/fhir/jpa/demo/FhirServerConfigDstu2.java
+++ b/src/main/java/ca/uhn/fhir/jpa/demo/FhirServerConfigDstu2.java
@@ -89,7 +89,7 @@ public class FhirServerConfigDstu2 extends BaseJavaConfigDstu2 {
 	/**
 	 * Do some fancy logging to create a nice access log that has details about each incoming request.
 	 */
-	public IServerInterceptor loggingInterceptor() {
+	public LoggingInterceptor loggingInterceptor() {
 		LoggingInterceptor retVal = new LoggingInterceptor();
 		retVal.setLoggerName("fhirtest.access");
 		retVal.setMessageFormat(
@@ -103,7 +103,7 @@ public class FhirServerConfigDstu2 extends BaseJavaConfigDstu2 {
 	 * This interceptor adds some pretty syntax highlighting in responses when a browser is detected
 	 */
 	@Bean(autowire = Autowire.BY_TYPE)
-	public IServerInterceptor responseHighlighterInterceptor() {
+	public ResponseHighlighterInterceptor responseHighlighterInterceptor() {
 		return new ResponseHighlighterInterceptor();
 	}
 

--- a/src/main/java/ca/uhn/fhir/jpa/demo/elasticsearch/FhirServerConfig.java
+++ b/src/main/java/ca/uhn/fhir/jpa/demo/elasticsearch/FhirServerConfig.java
@@ -77,7 +77,7 @@ public class FhirServerConfig extends BaseJavaConfigDstu3 {
 		extraProperties.put("hibernate.cache.use_minimal_puts", Boolean.FALSE.toString());
 
 		// the belowing properties are used for ElasticSearch integration
-		extraProperties.put(ElasticsearchEnvironment.ANALYZER_DEFINITION_PROVIDER, ElasticsearchMappingProvider.class.getName());
+		extraProperties.put(ElasticsearchEnvironment.ANALYSIS_DEFINITION_PROVIDER, ElasticsearchMappingProvider.class.getName());
 		extraProperties.put("hibernate.search.default.indexmanager", "elasticsearch");
 		extraProperties.put("hibernate.search.default.elasticsearch.host", "http://127.0.0.1:9200");
 		extraProperties.put("hibernate.search.default.elasticsearch.index_schema_management_strategy", "CREATE");
@@ -90,7 +90,7 @@ public class FhirServerConfig extends BaseJavaConfigDstu3 {
 	 * This interceptor adds some pretty syntax highlighting in responses when a browser is detected
 	 */
 	@Bean(autowire = Autowire.BY_TYPE)
-	public IServerInterceptor responseHighlighterInterceptor() {
+	public ResponseHighlighterInterceptor responseHighlighterInterceptor() {
 		return new ResponseHighlighterInterceptor();
 	}
 


### PR DESCRIPTION
## Proposed Changes

- Upgrade the starter to HAPI FHIR version 3.8.0
- Upgrade also the dependencies in the maven pom
- Adapt the starter to the new functionalities

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests
- [x] Build locally
- [ ] Code format / lint
- [ ] Docs have been reviewed and added

## Pull request type

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## What is the current behavior?

Currently we use HAPI FHIR version 3.3.0 and there is a potential security vulnerability. In any case from time to time we need to upgrade the version 

<!-- Link to a relevant issues and close issues that it fixes. -->
Fixes #4 

## What is the new behavior?

- Use the new ResourceProviderFactory for the beans
- Adapt the starter to the new interceptor framework
- java11 compliance

## Does this introduce a breaking change?

- [x] Yes
- [ ] No

There is a new interceptor framework and the ResourceProviderFactory. Covering also R4 specification.

## Other information

We need to improve the README, separate configs and adapt the starter to the [official project](https://github.com/hapifhir/hapi-fhir-jpaserver-starter)
