### PR TITLE
Optimize the Dockerfile to separate the builder from the runner. Include java 11 support. Refine the changelog template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,8 +88,6 @@ com_crashlytics_export_strings.xml
 crashlytics.properties
 crashlytics-build.properties
 
-
-
 ### Eclipse ###
 *.pydevproject
 .metadata
@@ -128,3 +126,5 @@ local.properties
 # TeXlipse plugin
 .texlipse
 
+# Okhttpcache
+.okhttpcache/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,31 @@
-FROM jetty:9-jre8-alpine
+# Copyright (C) 2019  Atos Spain SA. All rights reserved.
+# 
+# This file is part of the HAPI FHIR JPASERVER OAUTH.
+# 
+# This file is free software: you can redistribute it and/or modify it under the 
+# terms of the Apache License, Version 2.0 (the License);
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# The software is provided "AS IS", without any warranty of any kind, express or implied,
+# including but not limited to the warranties of merchantability, fitness for a particular
+# purpose and noninfringement, in no event shall the authors or copyright holders be 
+# liable for any claim, damages or other liability, whether in action of contract, tort or
+# otherwise, arising from, out of or in connection with the software or the use or other
+# dealings in the software.
+# 
+# See README file for the full disclaimer information and LICENSE file for full license 
+# information in the project root.
+
+FROM maven:3.6.0-jdk-11 as builder
+
+WORKDIR /code
+COPY pom.xml .
+RUN mvn dependency:resolve
+COPY src ./src
+RUN mvn package -Dmaven.test.skip=true
+
+FROM jetty:9.4-jre11 as runner
 USER jetty:jetty
-ADD ./target/hapi-fhir-jpaserver-oauth.war /var/lib/jetty/webapps/root.war
+COPY --from=builder /code/target/hapi-fhir-jpaserver-oauth.war /var/lib/jetty/webapps/root.war
 EXPOSE 8080

--- a/build-docker-image.sh
+++ b/build-docker-image.sh
@@ -1,5 +1,0 @@
-#!/bin/sh
-
-mvn package && \
-  docker build -t ccavero/hapi-fhir-jpaserver-oauth:0.0.1 .
-

--- a/changelog.json
+++ b/changelog.json
@@ -14,7 +14,7 @@
  
  "jiraIssuePattern": "jira\\b[a-zA-Z]([a-zA-Z]+)-([0-9]+)\\b",
 
- "gitHubApi": "https://api.github.com/repos/hapi-fhir-jpaserver-oauth/",
+ "gitHubApi": "https://api.github.com/repos/arihealth/hapi-fhir-jpaserver-oauth/",
  "gitHubIssuePattern": "#([0-9]+)",
 
  "customIssues": [

--- a/changelog.mustache
+++ b/changelog.mustache
@@ -8,23 +8,9 @@ Hapi-fhir-jpaserver-oauth is HAPI version 3.8.0 with support for mySQL and OAuth
 ## {{name}}
  {{#issues}}
   {{#hasIssue}}
-
-#### GitHub {{issue}} {{title}} {{#hasLabels}} {{#labels}} *{{.}}* {{/labels}} {{/hasLabels}}
+**Issue {{issue}}** - {{title}} {{#hasLabels}}{{#labels}}```{{.}}```{{/labels}}{{/hasLabels}}
   {{/hasIssue}}
   {{^hasIssue}}
-#### GitHub
   {{/hasIssue}}
-
-  {{#commits}}
-**{{{messageTitle}}}**
-
-{{#messageBodyItems}}
- * {{.}} 
-{{/messageBodyItems}}
-
-[{{hash}}](https://github.com/arihealth/hapi-fhir-jpaserver-oauth/commit/{{hash}}) {{authorName}} *{{commitTime}}*
-
-  {{/commits}}
-
  {{/issues}}
 {{/tags}}

--- a/changelog.mustache
+++ b/changelog.mustache
@@ -8,7 +8,8 @@ Hapi-fhir-jpaserver-oauth is HAPI version 3.8.0 with support for mySQL and OAuth
 ## {{name}}
  {{#issues}}
   {{#hasIssue}}
-**Issue {{issue}}** - {{title}} {{#hasLabels}}{{#labels}}```{{.}}```{{/labels}}{{/hasLabels}}
+### {{title}} {{#hasIssueType}} *{{issueType}}* {{/hasIssueType}} {{#hasLabels}} {{#labels}} ``{{.}}`` {{/labels}} {{/hasLabels}}
+* Further information in the Pull Request [{{issue}}]({{link}})
   {{/hasIssue}}
   {{^hasIssue}}
   {{/hasIssue}}

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
@@ -24,7 +25,7 @@
 		<!-- Dependency Versions -->
 		<derby_version>10.14.2.0</derby_version>
 		<jaxb_api_version>2.3.1</jaxb_api_version>
-		<jetty_version>9.4.14.v20181114</jetty_version>
+		<jetty_version>9.4.17.v20190418</jetty_version>
 		<phloc_schematron_version>2.7.1</phloc_schematron_version>
 		<spring_version>5.1.8.RELEASE</spring_version>
 		<thymeleaf-version>3.0.11.RELEASE</thymeleaf-version>
@@ -51,7 +52,7 @@
 			<url>https://oss.sonatype.org/content/repositories/snapshots/</url>
 		</repository>
 	</repositories>
-		
+
 	<profiles>
 		<profile>
 			<id>ut</id>
@@ -66,7 +67,7 @@
 				<skip.unit.tests>true</skip.unit.tests>
 			</properties>
 		</profile>
-	</profiles>  
+	</profiles>
 
 	<scm>
 		<url>https://github.com/AriHealth/hapi-fhir-jpaserver-oauth.git</url>
@@ -87,14 +88,14 @@
 	</distributionManagement>
 
 	<dependencies>
-	
+
 		<!-- JUnit -->
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
 			<version>4.12</version>
 		</dependency>
-		
+
 		<!-- Jetty -->
 		<dependency>
 			<groupId>org.eclipse.jetty.websocket</groupId>
@@ -111,7 +112,7 @@
 		<dependency>
 			<groupId>ca.uhn.hapi.fhir</groupId>
 			<artifactId>hapi-fhir-base</artifactId>
-			<version>${hapi.version}</version> 
+			<version>${hapi.version}</version>
 		</dependency>
 
 		<!-- At least one "structures" JAR must also be included -->
@@ -245,7 +246,7 @@
 		<dependency>
 			<groupId>org.eclipse.jetty</groupId>
 			<artifactId>jetty-server</artifactId>
-			<version>${jetty_version}</version>
+			<version>[9.4.17.v20190418,)</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
@@ -309,27 +310,6 @@
 						</webApp>
 					</configuration>
 				</plugin>
-
-				<plugin>
-					<groupId>se.bjurr.gitchangelog</groupId>
-					<artifactId>git-changelog-maven-plugin</artifactId>
-					<version>1.60</version>
-					<executions>
-						<execution>
-							<id>generateChangelog</id>
-							<phase>generate-sources</phase>
-							<goals>
-								<goal>git-changelog</goal>
-							</goals>
-							<configuration>
-								<gitHubToken>${GITHUB_API_TOKEN}</gitHubToken>
-								<templateFile>changelog.mustache</templateFile>
-								<settingsFile>changelog.json</settingsFile>
-								<file>CHANGELOG.md</file>
-							</configuration>
-						</execution>
-					</executions>
-				</plugin>
 			</plugins>
 		</pluginManagement>
 
@@ -338,6 +318,11 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.8.1</version>
+				<configuration>
+					<source>1.8</source>
+					<target>1.8</target>
+				</configuration>
 			</plugin>
 
 			<!-- The configuration here tells the WAR plugin to include the FHIR Tester 
@@ -364,13 +349,8 @@
 
 			<!-- This plugin is just a part of the HAPI internal build process, you 
 				do not need to incude it in your own projects -->
-			<!-- <plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-deploy-plugin</artifactId>
-				<configuration>
-					<skip>true</skip>
-				</configuration>
-			</plugin>  -->
+			<!-- <plugin> <groupId>org.apache.maven.plugins</groupId> <artifactId>maven-deploy-plugin</artifactId> 
+				<configuration> <skip>true</skip> </configuration> </plugin> -->
 
 			<!-- Add integration tests -->
 			<!-- Skip unit testing -->
@@ -404,7 +384,7 @@
 						</configuration>
 					</execution>
 				</executions>
-			</plugin> 
+			</plugin>
 
 			<plugin>
 				<artifactId>maven-release-plugin</artifactId>
@@ -433,19 +413,10 @@
 				</dependencies>
 			</plugin>
 
-			<plugin>
+			<!-- <plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>versions-maven-plugin</artifactId>
-			</plugin>
-
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
-				</configuration>
-			</plugin>
+			</plugin> --> 
 
 			<plugin>
 				<groupId>org.jacoco</groupId>
@@ -467,6 +438,26 @@
 				</executions>
 			</plugin>
 
+			<plugin>
+				<groupId>se.bjurr.gitchangelog</groupId>
+				<artifactId>git-changelog-maven-plugin</artifactId>
+				<version>1.60</version>
+				<executions>
+					<execution>
+						<id>generateChangelog</id>
+						<phase>generate-sources</phase>
+						<goals>
+							<goal>git-changelog</goal>
+						</goals>
+						<configuration>
+							<gitHubToken>${GITHUB_API_TOKEN}</gitHubToken>
+							<templateFile>changelog.mustache</templateFile>
+							<settingsFile>changelog.json</settingsFile>
+							<file>CHANGELOG.md</file>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
 


### PR DESCRIPTION
## Proposed Changes

  - Remove the changelog from PluginManagement section
  - Modify the mustache template to keep the changes clearer
  - Optimize the Dockerfile to separate the builder from the runner
  - Add java 11 and jetty 9.4

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] Tests
- [x] Build locally
- [x] Code format / lint
- [ ] Docs have been reviewed and added

## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## What is the current behavior?

Currently the docker image is generated using the builder_image script. 
Fixes #9 

## What is the new behavior?

- Lighter docker image
- Changelog clearer and readable for humans
- Automatic docker image generation in Docker Hub

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Build the docker image before accepting the PR.