### PR TITLE
PostgreSQL support as persistence layer

### DIFF
--- a/.env
+++ b/.env
@@ -1,28 +1,47 @@
-# General
+# Docker folder where the shared volumes are mounted
 CONFIG_FOLDER=/home/docker
 
 # Database configuration 
-# To be specified if keycloak reads DB_VENDOR in docker-compose.yaml
-# MariaDB
+# DB_VENDOR selects de DB strategy. 
+# It must be coherent with docker-compose.yaml, where database deployment is commented,
+# so remember to uncomment the one you prefer
+# DB_VENDOR= DERBY | MARIADB | POSTGRESQL | MYSQL
+# Default DERBY
+
+# In case DB_VENDOR is MYSQL
+# DB_VENDOR=MYSQL
+# DB_ROOT_PASSWORD=root
+# DB_USER=fhir
+# DB_PASSWORD=fhir
+# DB_DB=fhirdb
+# DB_HOST=mysql
+# DB_PORT=3306
+
+# In case DB_VENDOR is MARIADB
 # DB_VENDOR=MARIADB
-# PostgreSQL
-DB_VENDOR=POSTGRESQL
-DB_ROOT_PASSWORD=root
-DB_USER=fhir
-DB_PASSWORD=fhir
-DB_DB=fhirdb
+# DB_ROOT_PASSWORD=root
+# DB_USER=fhir
+# DB_PASSWORD=fhir
+# DB_DB=fhirdb
 # DB_HOST=mariadb
 # DB_PORT=3306
-DB_HOST=postgres
-DB_PORT=5432
+
+# In case DB_VENDOR is PostgreSQL
+# DB_VENDOR=POSTGRESQL
+# DB_USER=fhir
+# DB_PASSWORD=fhir
+# DB_DB=fhirdb
+# DB_HOST=postgres
+# DB_PORT=5432
 
 # KeyCloak
 KEYCLOAK_USER=admin
 KEYCLOAK_PASSWORD=Pa55w0rd
 
-# HAPI OAUTH
+# HAPI OAuth 2.0 configuration
+# To enable OAuth OAUTH_ENABLE=true
 OAUTH_URL=http://auth:8081/
-OAUTH_ENABLE=true
+OAUTH_ENABLE=false
 
 # KEYCLOAK AUTH
 KEYCLOAK_URL=http://keycloak:8080/auth

--- a/.env
+++ b/.env
@@ -3,14 +3,18 @@ CONFIG_FOLDER=/home/docker
 
 # Database configuration 
 # To be specified if keycloak reads DB_VENDOR in docker-compose.yaml
-#MariaDB
-DB_VENDOR=MARIADB
+# MariaDB
+# DB_VENDOR=MARIADB
+# PostgreSQL
+DB_VENDOR=POSTGRESQL
 DB_ROOT_PASSWORD=root
 DB_USER=fhir
 DB_PASSWORD=fhir
 DB_DB=fhirdb
-DB_HOST=mariadb
-DB_PORT=3306
+# DB_HOST=mariadb
+# DB_PORT=3306
+DB_HOST=postgres
+DB_PORT=5432
 
 # KeyCloak
 KEYCLOAK_USER=admin

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The following environment variables must be set prior to the execution:
 
 The project comes with a [docker-compose](https://docs.docker.com/compose/) which deploys testing containers for Keycloak (port: 9090), HAPI (8080), OAuth 2.0 and the authenticator (8081):
 
-0. Check the configuration values at the environment (`.env`) file. You can modify at your needs
+0. Check the configuration values at the environment (`.env`) file. Put OAUTH_ENABLE=true to protect the API. You can modify at your needs.
 1. Execute `docker-compose up -d`
 2. Wait a couple of minutes until the stack is deployed. Check the logs with `docker logs --details hapi-fhir`
 3. Access the Keycloak console `http://localhost:9090` (**user**: admin, **password**: Pa55w0rd)
@@ -105,7 +105,7 @@ Build the image:
 	docker build -t hapi-fhir/hapi-fhir-cdr .
 ```
 
-Use this command to start the container (take into account the links to auth and database containers). The possibilities for the DB_VENDOR are [DERBY, MYSQL, MARIADB, POSTGRESQL (DB_PORT 5432)]: 
+Use this command to start the container (take into account the links to auth and database containers). The possibilities for the DB_VENDOR are [DERBY, MYSQL, MARIADB, POSTGRESQL (DB_PORT 5432)]. For instance if MariaDB is selected the docker configuration is as follows: 
 ```
 	docker run -d --name hapi-fhir-cdr -p 8080:8080 hapi-fhir/hapi-fhir-cdr -e DB_VENDOR=MARIADB -e DB_HOST=mariadb -e DB_PORT=3306 -e DB_USER=fhiruser -e DB_PASSWORD=fhirpwd DB_DATABASE=fhirdb -e LUCENE_FOLDER=XXX OAUTH_ENABLE=true OAUTH_URL=http://auth:8081/ --link auth:auth --link mariadb:mariadb 
 ```

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -35,8 +35,8 @@ services:
 #  mysql:
 #    image: mysql:5.7
 #    container_name: mysql
-#    volumes:
-#      - ${CONFIG_FOLDER}/mysql/data:/var/lib/mysql
+##    volumes:
+##      - ${CONFIG_FOLDER}/mysql/data:/var/lib/mysql
 #    environment:
 #      MYSQL_ROOT_PASSWORD: ${DB_ROOT_PASSWORD}
 #      MYSQL_DATABASE: ${DB_DB}
@@ -49,23 +49,40 @@ services:
 #        retries: 3
 #    restart: always
 
-# MariaDB database for HAPI
-  mariadb:
-    image: mariadb/server:10.3
-    container_name: mariadb
+# PostgreSQL database for HAPI
+  postgres:
+    image: postgres
+    container_name: postgres
 #    volumes:
-#      - ${CONFIG_FOLDER}/mysql/data:/var/lib/mysql
+#      - ${CONFIG_FOLDER}/postgresql/data:/var/lib/postgresql/data
     environment:
-      MYSQL_ROOT_PASSWORD: ${DB_ROOT_PASSWORD}
-      MYSQL_DATABASE: ${DB_DB}
-      MYSQL_USER: ${DB_USER}
-      MYSQL_PASSWORD: ${DB_PASSWORD}
+      POSTGRES_DB: ${DB_DB}
+      POSTGRES_USER: ${DB_USER}
+      POSTGRES_PASSWORD: ${DB_PASSWORD}
     healthcheck:
-        test: ["CMD-SHELL", "mysqladmin -h 'localhost' -u root -p${DB_ROOT_PASSWORD} ping --silent"]
-        interval: 30s
-        timeout: 30s
-        retries: 3
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
     restart: always
+
+# MariaDB database for HAPI
+#  mariadb:
+#    image: mariadb/server:10.3
+#    container_name: mariadb
+##    volumes:
+##      - ${CONFIG_FOLDER}/mysql/data:/var/lib/mysql
+#    environment:
+#      MYSQL_ROOT_PASSWORD: ${DB_ROOT_PASSWORD}
+#      MYSQL_DATABASE: ${DB_DB}
+#      MYSQL_USER: ${DB_USER}
+#      MYSQL_PASSWORD: ${DB_PASSWORD}
+#    healthcheck:
+#        test: ["CMD-SHELL", "mysqladmin -h 'localhost' -u root -p${DB_ROOT_PASSWORD} ping --silent"]
+#        interval: 30s
+#        timeout: 30s
+#        retries: 3
+#    restart: always
 
   keycloak:
     image: jboss/keycloak
@@ -81,9 +98,6 @@ services:
   hapi-fhir:
     container_name: hapi-fhir
     build: .
-    depends_on:
-      hapi:
-          condition: service_healthy
     environment:
        # Specify DB_VENDOR if we want a non default db in Keycloak
       DB_VENDOR: ${DB_VENDOR}
@@ -91,23 +105,21 @@ services:
       DB_PORT: ${DB_PORT}
       DB_DATABASE: ${DB_DB}
       DB_USER: ${DB_USER}
-      DB_PASS: ${DB_PASSWORD}
+      DB_PASSWORD: ${DB_PASSWORD}
       OAUTH_URL: ${OAUTH_URL}  
       OAUTH_ENABLE: ${OAUTH_ENABLE}
     ports:
       - 8080:8080
     depends_on:
+      - auth
+      - postgres
       - keycloak
-      - mariadb
     restart: always
 
 # Auth service
   auth:
     image: ccavero/keycloak-auth:latest
     container_name: auth
-    depends_on:
-      keycloak:
-          condition: service_healthy
     environment:
       KEYCLOAK_URL: ${KEYCLOAK_URL}
       KEYCLOAK_REALM: ${KEYCLOAK_REALM}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -50,21 +50,21 @@ services:
 #    restart: always
 
 # PostgreSQL database for HAPI
-  postgres:
-    image: postgres
-    container_name: postgres
-#    volumes:
-#      - ${CONFIG_FOLDER}/postgresql/data:/var/lib/postgresql/data
-    environment:
-      POSTGRES_DB: ${DB_DB}
-      POSTGRES_USER: ${DB_USER}
-      POSTGRES_PASSWORD: ${DB_PASSWORD}
-    healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U postgres"]
-      interval: 10s
-      timeout: 5s
-      retries: 5
-    restart: always
+#  postgres:
+#    image: postgres
+#    container_name: postgres
+##    volumes:
+##      - ${CONFIG_FOLDER}/postgresql/data:/var/lib/postgresql/data
+#    environment:
+#      POSTGRES_DB: ${DB_DB}
+#      POSTGRES_USER: ${DB_USER}
+#      POSTGRES_PASSWORD: ${DB_PASSWORD}
+#    healthcheck:
+#      test: ["CMD-SHELL", "pg_isready -U postgres"]
+#      interval: 10s
+#      timeout: 5s
+#      retries: 5
+#    restart: always
 
 # MariaDB database for HAPI
 #  mariadb:
@@ -98,21 +98,23 @@ services:
   hapi-fhir:
     container_name: hapi-fhir
     build: .
-    environment:
-       # Specify DB_VENDOR if we want a non default db in Keycloak
-      DB_VENDOR: ${DB_VENDOR}
-      DB_HOST: ${DB_HOST}
-      DB_PORT: ${DB_PORT}
-      DB_DATABASE: ${DB_DB}
-      DB_USER: ${DB_USER}
-      DB_PASSWORD: ${DB_PASSWORD}
-      OAUTH_URL: ${OAUTH_URL}  
-      OAUTH_ENABLE: ${OAUTH_ENABLE}
+#    environment:
+#       # Specify DB_VENDOR in .env if you want a non default db in HAPI
+#      DB_VENDOR: ${DB_VENDOR}
+#      DB_HOST: ${DB_HOST}
+#      DB_PORT: ${DB_PORT}
+#      DB_DATABASE: ${DB_DB}
+#      DB_USER: ${DB_USER}
+#      DB_PASSWORD: ${DB_PASSWORD}
+#      OAUTH_URL: ${OAUTH_URL}  
+#      OAUTH_ENABLE: ${OAUTH_ENABLE}
     ports:
       - 8080:8080
     depends_on:
       - auth
-      - postgres
+#      - mysql
+#      - mariadb
+#      - postgres
       - keycloak
     restart: always
 

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,7 @@
 		<hapi.version>3.8.0</hapi.version>
 		<mariadb.version>2.4.3</mariadb.version>
 		<mysql.version>6.0.5</mysql.version>
+		<postgresql.version>42.2.6</postgresql.version>
 
 		<!-- javadoc and scm configuration for the CI -->
 		<maven.javadoc.failOnError>false</maven.javadoc.failOnError>
@@ -291,7 +292,13 @@
 		    <artifactId>mariadb-java-client</artifactId>
 		    <version>${mariadb.version}</version>
 		</dependency>
-
+		
+		<!-- PostgreSQL -->
+		<dependency>
+			<groupId>org.postgresql</groupId>
+			<artifactId>postgresql</artifactId>
+			<version>${postgresql.version}</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/net/atos/ari/cdr/starter/config/FhirServerConfig.java
+++ b/src/main/java/net/atos/ari/cdr/starter/config/FhirServerConfig.java
@@ -36,11 +36,14 @@ import net.atos.ari.cdr.starter.oauth2.KeyCloakInterceptor;
 public class FhirServerConfig extends BaseJavaConfigDstu3 {
 	private static final Logger LOGGER = LoggerFactory.getLogger(FhirServerConfig.class);
 
+	private static final String DEFAULT_MYSQL_PORT = "3306";
 	private static final String DEFAULT_LUCENE_FOLDER = "target/lucenefiles";
+	
 	private static final String MARIADB_VENDOR = "MARIADB";
 	private static final String MYSQL_VENDOR = "MYSQL";
-	private static final String MYSQL_DEFAULT_PORT = "3306";
+	private static final String POSTGRESQL_VENDOR = "POSTGRESQL";
 	private static final String DERBY_VENDOR = "DERBY";
+
 	private static final String LOCALHOST = "localhost";
 
 	// Const from properties
@@ -49,7 +52,7 @@ public class FhirServerConfig extends BaseJavaConfigDstu3 {
 	private static final String DB_HOST = System.getenv("DB_HOST") == null? 
 			LOCALHOST: System.getenv("DB_HOST");
 	private static final String DB_PORT = System.getenv("DB_PORT") == null? 
-			MYSQL_DEFAULT_PORT: System.getenv("DB_PORT");
+			DEFAULT_MYSQL_PORT: System.getenv("DB_PORT");
 	private static final String DB_USER = System.getenv("DB_USER") == null? 
 			"": System.getenv("DB_USER");
 	private static final String DB_PASSWORD = System.getenv("DB_PASSWORD") == null? 
@@ -92,17 +95,18 @@ public class FhirServerConfig extends BaseJavaConfigDstu3 {
 		try {
 			retVal.setUsername(DB_USER);
 			retVal.setPassword(DB_PASSWORD);
+			retVal.setUrl("jdbc:"+ DB_VENDOR.toLowerCase() +"://"+DB_HOST+":" + DB_PORT + "/" +
+					DB_DATABASE + "?useSSL=false&serverTimezone=UTC");
 
 			switch (DB_VENDOR) {
 				case MYSQL_VENDOR:
 					retVal.setDriver(new com.mysql.jdbc.Driver());
-					retVal.setUrl("jdbc:mysql://"+DB_HOST+":" + DB_PORT + "/" +
-							DB_DATABASE + "?useSSL=false&serverTimezone=UTC");
 					break;
 				case MARIADB_VENDOR:
 					retVal.setDriver(new org.mariadb.jdbc.Driver());
-					retVal.setUrl("jdbc:mariadb://"+DB_HOST+":" + DB_PORT + "/" +
-							DB_DATABASE + "?useSSL=false&serverTimezone=UTC");
+					break;
+				case POSTGRESQL_VENDOR:
+					retVal.setDriver(new org.postgresql.Driver());
 					break;
 				case DERBY_VENDOR:
 				default:
@@ -136,6 +140,9 @@ public class FhirServerConfig extends BaseJavaConfigDstu3 {
 				break;
 			case MARIADB_VENDOR:
 				extraProperties.put("hibernate.dialect", "org.hibernate.dialect.MariaDB103Dialect");
+				break;				
+			case POSTGRESQL_VENDOR:
+				extraProperties.put("hibernate.dialect", "org.hibernate.dialect.PostgreSQLDialect");
 				break;				
 			case DERBY_VENDOR:
 			default:

--- a/src/main/java/net/atos/ari/cdr/starter/config/FhirServerConfig.java
+++ b/src/main/java/net/atos/ari/cdr/starter/config/FhirServerConfig.java
@@ -37,6 +37,7 @@ public class FhirServerConfig extends BaseJavaConfigDstu3 {
 	private static final Logger LOGGER = LoggerFactory.getLogger(FhirServerConfig.class);
 
 	private static final String DEFAULT_MYSQL_PORT = "3306";
+	private static final String DEFAULT_POSTGRESQL_PORT = "5432";
 	private static final String DEFAULT_LUCENE_FOLDER = "target/lucenefiles";
 	
 	private static final String MARIADB_VENDOR = "MARIADB";
@@ -51,8 +52,7 @@ public class FhirServerConfig extends BaseJavaConfigDstu3 {
 			DERBY_VENDOR: System.getenv("DB_VENDOR");
 	private static final String DB_HOST = System.getenv("DB_HOST") == null? 
 			LOCALHOST: System.getenv("DB_HOST");
-	private static final String DB_PORT = System.getenv("DB_PORT") == null? 
-			DEFAULT_MYSQL_PORT: System.getenv("DB_PORT");
+	private static String DB_PORT = null;
 	private static final String DB_USER = System.getenv("DB_USER") == null? 
 			"": System.getenv("DB_USER");
 	private static final String DB_PASSWORD = System.getenv("DB_PASSWORD") == null? 
@@ -93,26 +93,32 @@ public class FhirServerConfig extends BaseJavaConfigDstu3 {
 	public BasicDataSource dataSource() {
 		BasicDataSource retVal = new BasicDataSource();
 		try {
-			retVal.setUsername(DB_USER);
-			retVal.setPassword(DB_PASSWORD);
-			retVal.setUrl("jdbc:"+ DB_VENDOR.toLowerCase() +"://"+DB_HOST+":" + DB_PORT + "/" +
-					DB_DATABASE + "?useSSL=false&serverTimezone=UTC");
 
 			switch (DB_VENDOR) {
 				case MYSQL_VENDOR:
 					retVal.setDriver(new com.mysql.jdbc.Driver());
+					DB_PORT = System.getenv("DB_PORT") == null? 
+							DEFAULT_MYSQL_PORT: System.getenv("DB_PORT");
 					break;
 				case MARIADB_VENDOR:
 					retVal.setDriver(new org.mariadb.jdbc.Driver());
+					DB_PORT = System.getenv("DB_PORT") == null? 
+							DEFAULT_MYSQL_PORT: System.getenv("DB_PORT");
 					break;
 				case POSTGRESQL_VENDOR:
 					retVal.setDriver(new org.postgresql.Driver());
+					DB_PORT = System.getenv("DB_PORT") == null? 
+							DEFAULT_POSTGRESQL_PORT: System.getenv("DB_PORT");
 					break;
 				case DERBY_VENDOR:
 				default:
 					retVal.setDriver(new org.apache.derby.jdbc.EmbeddedDriver());
 					retVal.setUrl("jdbc:derby:directory:target/jpaserver_derby_files;create=true");
 			}
+			retVal.setUsername(DB_USER);
+			retVal.setPassword(DB_PASSWORD);
+			retVal.setUrl("jdbc:"+ DB_VENDOR.toLowerCase() +"://"+DB_HOST+":" + DB_PORT + "/" +
+					DB_DATABASE + "?useSSL=false&serverTimezone=UTC");
 			return retVal;
 		} catch (SQLException sqlex) {
 			LOGGER.error("Exception in database connection", sqlex);


### PR DESCRIPTION
## Proposed Changes

  - Add the dependencies to the maven pom
  - Configure the driver and hibernate if the DB_VENDOR env variable is POSTGRESQL
  - Modify the docker-compose and .env for testing

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests
- [x] Build locally
- [ ] Code format / lint
- [x] Docs have been reviewed and added

## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Documentation content changes
- [ ] Other (please describe): 

## What is the current behavior?

Cover Derby, MySQL and MariaDB

Issue Number: #8 

Fixes #16 

## What is the new behavior?

- PostgreSQL can be configured as database with DB_VENDOR environment variable
- It can be tested using docker-compose

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Docker-compose has a lot of comments (mysql and mariadb containers for instance). I left them to ease the testing part of the different databases. I do not know if it is somewhat confusing.
