### PR TITLE
Fix incorrect jdbc url when running derby database

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,18 +4,16 @@
 
 ## Description
 
-Hapi-fhir-jpaserver-oauth is HAPI v 3.8.0-SNAPSHOT with support for mySQL and OAuth. 
+Open-source implementation of the FHIR specification in Java based on [HAPI](http://hapifhir.io/). HAPI FHIR CDR with support for several databases (Derby, MySQL, MariaDB and PostgreSQL) and OAuth. 
+
 
 ## Technology
 
 - Java 11
 - Maven for Java dependency management
 - Jetty
-- Spring Framework 
-
-## Functionalities
-
-- Open-source implementation of the FHIR specification in Java based on [HAPI](http://hapifhir.io/).
+- Spring Framework
+- [HAPI](http://hapifhir.io/)
 
 ## How to deploy
 
@@ -31,43 +29,64 @@ and deploy with:
 mvn jetty:run
 ```
 
-Go to your browser and type http://localhost:8080/hapi
-
-If you enable the OAuth capability (see next section) deploy the [Keycloak OAuth 2.0](https://github.com/AriHealth/keycloak-auth) and dependencies.
+Go to your browser and type http://localhost:8080/hapi. If you enable the OAuth capability (see next section) deploy the [Keycloak OAuth 2.0](https://github.com/AriHealth/keycloak-auth) and dependencies.
 
 ## Environment variables
 
 The following environment variables must be set prior to the execution:
 
-	DB_VENDOR=DERBY - List of possible vendors [DERBY,MYSQL,MARIADB]
-	DB_HOST=localhost - Host where the database is deployed (it can be empty for DERBY)
-	DB_PORT=3306 -  - Port where the database is deployed (it can be empty for DERBY)
-	DB_USER=fhiruser - FHIR user for the database (it can be empty for DERBY)
-	DB_PASSWORD=fhirpwd
-	DB_DATABASE=fhirdb
-	LUCENE_FOLDER=/var/lib/tomcat8/webapps/hapi/indexes - Place where the Lucene index are stored
-	OAUTH_ENABLE=false - To enable/disable authentication
-	OAUTH_URL=http://auth:8081 - In case of enabling authentication, the url where the Keycloak OAuth 2.0 is available
+* `DB_VENDOR`: Specify vendor. The list of possible vendors are [`DERBY`, `MYSQL`, `MARIADB`, `POSTGRESQL`] (`optional`, default value `DERBY`)
+* `DB_HOST`: Host where the database is deployed (it can be empty for `DERBY`) (`optional`, default value `localhost`)
+* `DB_PORT`: Port where the database is deployed (it can be empty for `DERBY`) (`optional`, default value `3306` for `MYSQL`, `5432` for `POSTGRESQL).
+* `DB_USER`: FHIR user for the database (it can be empty for `DERBY`) (`optional`, default value `fhiruser`). 
+* `DB_PASSWORD`: Password for `DB_USER` in the database (it can be empty for `DERBY`) (`optional`, default value `fhirpwd`).
+* `DB_DATABASE`: DB for the database (it can be empty for `DERBY`) (`optional`, default value `fhirdb`).
+* `LUCENE_FOLDER`: Place where the Lucene index are stored (`optional`, default value `/var/lib/tomcat8/webapps/hapi/indexes`).
+* `OAUTH_ENABLE`: To enable/disable authentication (`optional`, default value `false`).
+* `OAUTH_URL`: In case of enabling authentication, the url where the Keycloak OAuth 2.0 is available (`optional`, default value `http://auth:8081`).
+
+## Database
+
+This image supports `Derby`, `MySQL`, `MariaDB` and `PostgreSQL`. To configure the database use `DB_VENDOR` with the following values [`DERBY`, `MYSQL`, `MARIADB`, `POSTGRESQL`].
+
+### Derby
+
+No container is needed.
+
+### MySQL
+```
+	docker run -d --name mysql -e MYSQL_ROOT_PASSWORD=rootpwd -e MYSQL_USER=fhiruser -e MYSQL_PASSWORD=fhirpwd MYSQL_DATABASE=fhirdb mysql:5.7
+```
+
+### MariaDB
+```
+	docker run -d --name mariadb -e MYSQL_ROOT_PASSWORD=rootpwd -e MYSQL_USER=fhiruser -e MYSQL_PASSWORD=fhirpwd MYSQL_DATABASE=fhirdb mariadb/server:10.3
+```
+
+### PostgreSQL
+```
+	docker run -d --name postgres -e POSTGRES_USER=fhiruser -e POSTGRES_PASSWORD=fhirpwd POSTGRES_DB=fhirdb postgres
+```
 
 ## Docker deployment
 
 ### Full stack deployment using docker-compose
 
-The project comes with a [docker-compose](https://docs.docker.com/compose/) which deploys testing containers for Keycloak (port: 9090), HAPI (8080), OAuth 2.0 and the authenticator (8081):
+The project comes with a [docker-compose](https://docs.docker.com/compose/) which deploys testing containers for Keycloak (port: 9090), HAPI (8080), OAuth 2.0 Authenticator (8081):
 
-0. Check the configuration values at the environment (`.env`) file. Put OAUTH_ENABLE=true to protect the API. You can modify at your needs.
+0. Check the configuration values at the environment (`.env`) file. Put `OAUTH_ENABLE`=`true` to protect the API. You can modify at your needs.
 1. Execute `docker-compose up -d`
 2. Wait a couple of minutes until the stack is deployed. Check the logs with `docker logs --details hapi-fhir`
 3. Access the Keycloak console `http://localhost:9090` (**user**: admin, **password**: Pa55w0rd)
-* Create a realm `HAPIFHIR`
-* Inside the realm create a client_id: `hapifhir-client`
-* Create a user: test. Modify the creadentials (temporary off)
+      * Create a realm `HAPIFHIR`
+      * Inside the realm create a client_id: `hapifhir-client`
+      * Create a user: test. Modify the creadentials (temporary off)
 4. Access the authenticator `http://localhost:8081/swagger-ui.html`
-* Open Login operation under Auth controller, `Try it out`:
-* In the JSON include the user created in Keycloak (`test`)
-* The response is a OAuth access token
-* Copy the access token
-* Last thing is to configure the [HAPI client including the authorization token in the header](http://hapifhir.io/doc_rest_client_interceptor.html). Authorization header: `Bearer <access token>` (see the java snippet below)
+      * Open Login operation under Auth controller, `Try it out`:
+      * In the JSON include the user created in Keycloak (`test`)
+      * The response is a OAuth access token
+      * Copy the access token
+      * Last thing is to configure the [HAPI client including the authorization token in the header](http://hapifhir.io/doc_rest_client_interceptor.html). Authorization header: `Bearer <access token>` (see the java snippet below)
 ```
 		BearerTokenAuthInterceptor authInterceptor = new BearerTokenAuthInterceptor(token); 
 		// Create a client and post the transaction to the server
@@ -79,37 +98,15 @@ The project comes with a [docker-compose](https://docs.docker.com/compose/) whic
 
 ### Simple deployment
 
-It is supposed [auth](https://hub.docker.com/r/ccavero/keycloak-auth) are deployed (check the docker-compose deployment for the full stack).
-
-#### Database
-
-Deploy a MySQL instance:
-```
-	docker run -d --name mysql -e MYSQL_ROOT_PASSWORD=rootpwd -e MYSQL_USER=fhiruser -e MYSQL_PASSWORD=fhirpwd MYSQL_DATABASE=fhirdb mysql:5.7
-```
-
-Deploy a MariaDB instance:
-```
-	docker run -d --name mariadb -e MYSQL_ROOT_PASSWORD=rootpwd -e MYSQL_USER=fhiruser -e MYSQL_PASSWORD=fhirpwd MYSQL_DATABASE=fhirdb mariadb/server:10.3
-```
-
-Deploy a PostgreSQL instance:
-```
-	docker run -d --name postgres -e POSTGRES_USER=fhiruser -e POSTGRES_PASSWORD=fhirpwd POSTGRES_DB=fhirdb postgres
-```
-
-#### HAPI CDR
-
 Build the image:
 ```
 	docker build -t hapi-fhir/hapi-fhir-cdr .
 ```
 
-Use this command to start the container (take into account the links to auth and database containers). The possibilities for the DB_VENDOR are [DERBY, MYSQL, MARIADB, POSTGRESQL (DB_PORT 5432)]. For instance if MariaDB is selected the docker configuration is as follows: 
+It is supposed [auth](https://hub.docker.com/r/ccavero/keycloak-auth) is deployed. Use this command to start the container (take into account the links to auth and database containers).  For instance if MariaDB is selected the docker configuration is as follows: 
 ```
-	docker run -d --name hapi-fhir-cdr -p 8080:8080 hapi-fhir/hapi-fhir-cdr -e DB_VENDOR=MARIADB -e DB_HOST=mariadb -e DB_PORT=3306 -e DB_USER=fhiruser -e DB_PASSWORD=fhirpwd DB_DATABASE=fhirdb -e LUCENE_FOLDER=XXX OAUTH_ENABLE=true OAUTH_URL=http://auth:8081/ --link auth:auth --link mariadb:mariadb 
+	docker run -d --name hapi-fhir-cdr -p 8080:8080 arihealth/hapi-fhir-cdr-oauth -e DB_VENDOR=MARIADB -e DB_HOST=mariadb -e DB_PORT=3306 -e DB_USER=fhiruser -e DB_PASSWORD=fhirpwd DB_DATABASE=fhirdb -e LUCENE_FOLDER=XXX OAUTH_ENABLE=true OAUTH_URL=http://auth:8081/ --link auth:auth --link mariadb:mariadb 
 ```
-
 Note: with this command data is persisted across container restarts, but not after removal of the container. Use a new container for the database with a shared docker volume.
 
 ## MySQL configuration

--- a/src/main/java/net/atos/ari/cdr/starter/config/FhirServerConfig.java
+++ b/src/main/java/net/atos/ari/cdr/starter/config/FhirServerConfig.java
@@ -117,7 +117,8 @@ public class FhirServerConfig extends BaseJavaConfigDstu3 {
 			}
 			retVal.setUsername(DB_USER);
 			retVal.setPassword(DB_PASSWORD);
-			retVal.setUrl("jdbc:"+ DB_VENDOR.toLowerCase() +"://"+DB_HOST+":" + DB_PORT + "/" +
+			if (DB_VENDOR.equalsIgnoreCase(DERBY_VENDOR) == false)
+				retVal.setUrl("jdbc:"+ DB_VENDOR.toLowerCase() +"://"+DB_HOST+":" + DB_PORT + "/" +
 					DB_DATABASE + "?useSSL=false&serverTimezone=UTC");
 			return retVal;
 		} catch (SQLException sqlex) {


### PR DESCRIPTION
## Proposed Changes

  - Improve the README file
  - The jdbc url is not overwritten when the `DB_VENDOR` is not `Derby`

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] Tests
- [ ] Build locally
- [ ] Code format / lint
- [x] Docs have been reviewed and added

## Pull request type

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Documentation content changes
- [ ] Other (please describe): 

## What is the current behavior?

Whe configure Derby as persistence layer the application crashes because it does not find the configuration

<!-- Link to a relevant issues and close issues that it fixes. -->
Fixes #19 

## What is the new behavior?

- Correct deployment when Derby is selected (by default)

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

It seems the tests were correct in the previous PR and it did not work. So we need to check the CI pipeline.